### PR TITLE
.gitignoreに項目を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,15 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# firebase sdk keys
+android/app/google-services.json
+android/app/**/google-services.json
+ios/Runner/GoogleService-Info.plist
+ios/Runner/**/GoogleService-Info.plist
+ios/firebase_app_id_file.json
+macos/Runner/GoogleService-Info.plist
+macos/firebase_app_id_file.json
+
+#fvm related
+.fvm/flutter_sdk


### PR DESCRIPTION
APIキーを含んでいるFirebase構成ファイルおよび、fvmのflutter sdkをGit管理から外すようにした。